### PR TITLE
Fixed minor indexing bug in Chunk.h

### DIFF
--- a/open_chisel/include/open_chisel/Chunk.h
+++ b/open_chisel/include/open_chisel/Chunk.h
@@ -80,7 +80,7 @@ namespace chisel
 
             inline VoxelID GetVoxelID(int x, int y, int z) const
             {
-                return (z * numVoxels(2) + y) * numVoxels(0) + x;
+                return (z * numVoxels(1) + y) * numVoxels(0) + x;
             }
 
             inline const DistVoxel& GetDistVoxel(int x, int y, int z) const


### PR DESCRIPTION
This is a fix for a small indexing bug in Chunk.h.  You would only see an effect if your Y and Z chunk sizes were different.  Since chunk indexes are always looked up through this one function, it doesn't affect the overall output.
